### PR TITLE
FIX: Read_ogg(): fixed faulty loop and added result value

### DIFF
--- a/oggvorbis.mod/oggdecoder.c
+++ b/oggvorbis.mod/oggdecoder.c
@@ -59,9 +59,11 @@ void *Decode_Ogg(void *stream,void *oread,void *oseek,void *oclose,void *otell,i
 
 int Read_Ogg(oggio *ogg,char *buf,int bytes)	// null buffer to close
 {
-	int		res,bs;
+	int		res,bs,read;
 
 	if (buf==0) return ov_clear(&ogg->vf);
+
+	read = 0;
 
 	while (bytes>0)
 	{
@@ -71,8 +73,13 @@ int Read_Ogg(oggio *ogg,char *buf,int bytes)	// null buffer to close
 			if (bs) return -1;	// Only one logical bitstream currently supported
 			return -2;			// Warning: hole in data
 		}
+		else if (res == 0) // reached eof
+		{
+			return read;
+		}
+		read+=res;
 		buf+=res;
 		bytes-=res;
 	}
-	return 0;
+	return read;
 }

--- a/oggvorbis.mod/oggvorbis.bmx
+++ b/oggvorbis.mod/oggvorbis.bmx
@@ -57,6 +57,6 @@ Function Decode_Ogg:Byte Ptr(..
 	tello(src:Object ),..
 	samples Var,channels Var,freq Var)
 
-Function Read_Ogg(ogg:Byte Ptr,buf:Byte Ptr,size)	'null buffer to close
+Function Read_Ogg:int(ogg:Byte Ptr,buf:Byte Ptr,size)	'null buffer to close
 
 End Extern


### PR DESCRIPTION
Before: only errors were returned (-2, -1) in all other cases 0. If the you were not able to read enough bytes, the contained while-loop might run forever because the result "0" was never evaluated.
