### PR TITLE
Fixed WM_DPICHANGED to make Brl maxgui build

### DIFF
--- a/win32.mod/user32.bmx
+++ b/win32.mod/user32.bmx
@@ -197,6 +197,7 @@ Const WS_EX_NOACTIVATE=$8000000
 
 ' windows messages
 
+Const WM_DPICHANGED = $2E0
 Const WM_APP=32768
 Const WM_ACTIVATE=6
 Const WM_ACTIVATEAPP=28
@@ -722,6 +723,7 @@ Function SendMessageW( hWnd,MSG,wParam,lParam )
 Function PostThreadMessageA( idThread,Msg,wParam,lParam )
 Function PostThreadMessageW( idThread,Msg,wParam,lParam )
 Function GetDC( hWnd )
+Function ReleaseDC( hwnd, hdc )
 Function PostQuitMessage( nExitCode )
 Function TranslateMessage( lpMsg:Byte Ptr )
 Function DestroyWindow( hWnd )


### PR DESCRIPTION
This is to make brl.maxgui build with Maxmods pub.mod. 

For some reason the const WM_DPICHANGED and function ReleaseDC were removed from win32/user32.bmx, I can't find a Maxmods Maxgui so I wonder how was this missed? 
